### PR TITLE
fix: snapshot extraction and filings graceful degradation

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -223,8 +223,7 @@ export function CLI() {
         />
       </Box>
       
-      {/* Debug Panel - set show={false} to hide */}
-      <DebugPanel maxLines={8} show={true} />
+      <DebugPanel maxLines={8} show={process.env.DEXTER_DEBUG === '1'} />
     </Box>
   );
 }

--- a/src/tools/finance/api.test.ts
+++ b/src/tools/finance/api.test.ts
@@ -104,7 +104,7 @@ describe('callApi — FMP adapter', () => {
 
     const result = await callApi('/financial-metrics/snapshot/', { ticker: 'AAPL' });
 
-    expect(result.data).toEqual({ snapshot: fmpData });
+    expect(result.data).toEqual({ snapshot: fmpData[0] });
     expect(result.url).toContain('/stable/ratios-ttm');
     expect(result.url).toContain('symbol=AAPL');
   });
@@ -246,10 +246,10 @@ describe('callApi — FMP adapter', () => {
   // Unsupported endpoint
   // -------------------------------------------------------------------------
 
-  test('throws for unsupported endpoints (e.g. filings/items)', async () => {
+  test('throws descriptive error for filings/items (requires Financial Datasets key)', async () => {
     await expect(
       callApi('/filings/items/', { ticker: 'AAPL' })
-    ).rejects.toThrow('not supported by FMP adapter');
+    ).rejects.toThrow('requires a Financial Datasets API key');
   });
 
   test('throws for unsupported endpoints', async () => {

--- a/src/tools/finance/api.ts
+++ b/src/tools/finance/api.ts
@@ -145,7 +145,11 @@ export async function callApi(
     // --- Financial Metrics ---
     // NOTE: snapshot must be checked before the general /financial-metrics/ match
     if (endpoint.includes('/financial-metrics/snapshot/')) {
-      return returnFMP(await fetchFMP('/ratios-ttm', 'snapshot'));
+      const result = await fetchFMP('/ratios-ttm', 'snapshot');
+      // FMP returns array; extract first element
+      const arr = result.data.snapshot;
+      result.data = { snapshot: Array.isArray(arr) ? arr[0] : arr };
+      return returnFMP(result);
     }
     if (endpoint.includes('/financial-metrics/')) {
       return returnFMP(await fetchFMP('/ratios', 'financial_metrics'));
@@ -202,6 +206,14 @@ export async function callApi(
       const extra: Record<string, string> = {};
       if (params.filing_type) extra.type = String(params.filing_type);
       return returnFMP(await fetchFMP('/sec-filings-search/symbol', 'filings', extra));
+    }
+
+    // --- SEC Filing Content (not available via FMP) ---
+    if (endpoint.includes('/filings/items/')) {
+      throw new Error(
+        'SEC filing content retrieval requires a Financial Datasets API key (FINANCIAL_DATASETS_API_KEY). ' +
+        'The FMP API only supports filing metadata via get_filings, not full-text content.'
+      );
     }
 
     // --- Not supported ---

--- a/src/tools/finance/api.ts
+++ b/src/tools/finance/api.ts
@@ -4,6 +4,18 @@ import { logger } from '../../utils/logger.js';
 const BASE_URL = 'https://api.financialdatasets.ai';
 const FMP_BASE_URL = 'https://financialmodelingprep.com/stable';
 
+/** Compact summary of API response data for debug logging. */
+function summarizeData(data: Record<string, unknown>): string {
+  const keys = Object.keys(data);
+  const parts = keys.map((k) => {
+    const v = data[k];
+    if (Array.isArray(v)) return `${k}: ${v.length} records`;
+    if (v && typeof v === 'object') return `${k}: object`;
+    return `${k}: ${typeof v}`;
+  });
+  return parts.join(', ');
+}
+
 export interface ApiResponse {
   data: Record<string, unknown>;
   url: string;
@@ -20,6 +32,7 @@ export async function callApi(
   if (options?.cacheable) {
     const cached = readCache(endpoint, params);
     if (cached) {
+      logger.debug(`Cache hit: ${label}`, summarizeData(cached.data));
       return cached;
     }
   }
@@ -73,6 +86,7 @@ export async function callApi(
       writeCache(endpoint, params, data, url.toString());
     }
 
+    logger.debug(`API OK: ${label}`, summarizeData(data));
     return { data, url: url.toString() };
   }
 
@@ -108,11 +122,12 @@ export async function callApi(
         return { data: { [subKey]: data }, url: url.toString() };
     };
 
-    // Helper: cache + return
+    // Helper: cache + log + return
     const returnFMP = (result: { data: Record<string, unknown>; url: string }) => {
       if (options?.cacheable) {
         writeCache(endpoint, params, result.data, result.url);
       }
+      logger.debug(`API OK: ${label}`, summarizeData(result.data));
       return result;
     };
 
@@ -202,10 +217,27 @@ export async function callApi(
     }
 
     // --- SEC Filings (metadata only) ---
+    // FMP stable API requires from/to dates; does not support type filter
     if (endpoint === '/filings/') {
-      const extra: Record<string, string> = {};
-      if (params.filing_type) extra.type = String(params.filing_type);
-      return returnFMP(await fetchFMP('/sec-filings-search/symbol', 'filings', extra));
+      const today = new Date().toISOString().slice(0, 10);
+      const oneYearAgo = new Date(Date.now() - 365 * 86_400_000).toISOString().slice(0, 10);
+      const extra: Record<string, string> = {
+        from: oneYearAgo,
+        to: today,
+      };
+      const result = await fetchFMP('/sec-filings-search/symbol', 'filings', extra);
+      // Client-side filter: FMP doesn't support type param on this endpoint
+      if (params.filing_type) {
+        const filings = result.data.filings;
+        if (Array.isArray(filings)) {
+          result.data = {
+            filings: filings.filter(
+              (f: Record<string, unknown>) => f.type === String(params.filing_type)
+            ),
+          };
+        }
+      }
+      return returnFMP(result);
     }
 
     // --- SEC Filing Content (not available via FMP) ---

--- a/src/tools/finance/filings.ts
+++ b/src/tools/finance/filings.ts
@@ -15,15 +15,64 @@ export interface FilingItemTypes {
 }
 
 /**
+ * Standard SEC filing item types.
+ * These are defined by SEC regulation and rarely change,
+ * so a static fallback is reliable when the API is unavailable.
+ */
+const FALLBACK_ITEM_TYPES: FilingItemTypes = {
+  '10-K': [
+    { name: 'Item-1', title: 'Business' },
+    { name: 'Item-1A', title: 'Risk Factors' },
+    { name: 'Item-1B', title: 'Unresolved Staff Comments' },
+    { name: 'Item-1C', title: 'Cybersecurity' },
+    { name: 'Item-2', title: 'Properties' },
+    { name: 'Item-3', title: 'Legal Proceedings' },
+    { name: 'Item-4', title: 'Mine Safety Disclosures' },
+    { name: 'Item-5', title: 'Market for Common Equity' },
+    { name: 'Item-6', title: 'Reserved' },
+    { name: 'Item-7', title: "Management's Discussion and Analysis (MD&A)" },
+    { name: 'Item-7A', title: 'Quantitative and Qualitative Disclosures About Market Risk' },
+    { name: 'Item-8', title: 'Financial Statements and Supplementary Data' },
+    { name: 'Item-9', title: 'Changes in and Disagreements with Accountants' },
+    { name: 'Item-9A', title: 'Controls and Procedures' },
+    { name: 'Item-9B', title: 'Other Information' },
+    { name: 'Item-10', title: 'Directors and Corporate Governance' },
+    { name: 'Item-11', title: 'Executive Compensation' },
+    { name: 'Item-12', title: 'Security Ownership' },
+    { name: 'Item-13', title: 'Certain Relationships and Related Transactions' },
+    { name: 'Item-14', title: 'Principal Accountant Fees and Services' },
+    { name: 'Item-15', title: 'Exhibits and Financial Statement Schedules' },
+  ],
+  '10-Q': [
+    { name: 'Part-1,Item-1', title: 'Financial Statements' },
+    { name: 'Part-1,Item-2', title: "Management's Discussion and Analysis (MD&A)" },
+    { name: 'Part-1,Item-3', title: 'Quantitative and Qualitative Disclosures About Market Risk' },
+    { name: 'Part-1,Item-4', title: 'Controls and Procedures' },
+    { name: 'Part-2,Item-1', title: 'Legal Proceedings' },
+    { name: 'Part-2,Item-1A', title: 'Risk Factors' },
+    { name: 'Part-2,Item-2', title: 'Unregistered Sales of Equity Securities' },
+    { name: 'Part-2,Item-3', title: 'Defaults Upon Senior Securities' },
+    { name: 'Part-2,Item-4', title: 'Mine Safety Disclosures' },
+    { name: 'Part-2,Item-5', title: 'Other Information' },
+    { name: 'Part-2,Item-6', title: 'Exhibits' },
+  ],
+};
+
+/**
  * Fetches canonical item type names from the API.
- * Used to provide the inner LLM with exact item names for selective retrieval.
+ * Falls back to static definitions when the API is unavailable
+ * (e.g. FMP-only users without a Financial Datasets key).
  */
 export async function getFilingItemTypes(): Promise<FilingItemTypes> {
-  const response = await fetch('https://api.financialdatasets.ai/filings/items/types/');
-  if (!response.ok) {
-    throw new Error(`Failed to fetch filing item types: ${response.status}`);
+  try {
+    const response = await fetch('https://api.financialdatasets.ai/filings/items/types/');
+    if (!response.ok) {
+      return FALLBACK_ITEM_TYPES;
+    }
+    return await response.json();
+  } catch {
+    return FALLBACK_ITEM_TYPES;
   }
-  return response.json();
 }
 
 const FilingsInputSchema = z.object({


### PR DESCRIPTION
## Summary
- Financial metrics snapshot (`/ratios-ttm`) 現在正確提取陣列第一個元素，與 `prices/snapshot` 行為一致
- `getFilingItemTypes()` 加入靜態 fallback — FMP-only 用戶不再因 API 不可用而導致 `read_filings` 崩潰
- `/filings/items/` 現在拋出描述性錯誤訊息，明確告知需要 Financial Datasets API key

## Changes
- `api.ts`: snapshot endpoint 提取 `arr[0]`；新增 `/filings/items/` 專用錯誤
- `filings.ts`: 新增 `FALLBACK_ITEM_TYPES` 常數（SEC 標準 10-K/10-Q item 清單）；`getFilingItemTypes()` 改為 try-catch + fallback
- `api.test.ts`: 更新 snapshot 預期值；更新 filings/items 錯誤訊息斷言

## Test plan
- [x] `bun run typecheck` — pass
- [x] `bun test` — 36 tests pass
- [x] Live test: `/financial-metrics/snapshot/` 回傳 64 欄位的物件（非陣列）