### PR TITLE
fix: harden FMP adapter error handling and endpoint guards

### DIFF
--- a/src/tools/finance/company_facts.ts
+++ b/src/tools/finance/company_facts.ts
@@ -11,7 +11,7 @@ const CompanyFactsInputSchema = z.object({
 
 export const getCompanyFacts = new DynamicStructuredTool({
   name: 'get_company_facts',
-  description: `Retrieves company facts and metadata for a given ticker, including sector, industry, market cap, number of employees, listing date, exchange, location, weighted average shares,  website. Useful for getting an overview of a company's profile and basic information.`,
+  description: `Retrieves company facts and metadata for a given ticker, including sector, industry, market cap, number of employees, listing date, exchange, location, weighted average shares, website. Useful for getting an overview of a company's profile and basic information.`,
   schema: CompanyFactsInputSchema,
   func: async (input) => {
     const { data, url } = await callApi('/company/facts', { ticker: input.ticker });


### PR DESCRIPTION
## Summary
- **fetchFMP network error handling**: Added try-catch around `fetch()` in FMP adapter (matches Financial Datasets path behavior). Previously network failures (DNS, timeout) would throw unhandled `TypeError` without logging.
- **fetchFMP JSON parse error handling**: Added `.catch()` on `res.json()` for invalid JSON responses (e.g. HTML error pages from FMP). Previously would throw an unclear error.
- **Crypto endpoint descriptive error**: FMP adapter now returns a clear error message for `/crypto/` endpoints explaining they require a Financial Datasets API key. Previously would either silently match `/prices/snapshot` or hit the generic "not supported" error.
- **Aggregated endpoint debug log**: Added missing `logger.debug()` call for the `/financials/` aggregated path — was the only FMP endpoint without debug logging.
- **Typo fix**: Removed double space in `company_facts.ts` description.

## Test plan
- [x] 40 tests pass (3 new: crypto error, network error, JSON parse error)
- [x] TypeScript typecheck passes
- [x] Manual: verify crypto tool shows descriptive error with FMP-only key